### PR TITLE
MauiSignin: Check if PortalUser has a thumbnail before using it

### DIFF
--- a/src/MauiSignin/AppSettings.cs
+++ b/src/MauiSignin/AppSettings.cs
@@ -1,4 +1,4 @@
-﻿using Esri.ArcGISRuntime.Portal;
+using Esri.ArcGISRuntime.Portal;
 using System.ComponentModel;
 
 namespace MauiSignin;
@@ -44,7 +44,14 @@ internal class AppSettings : ModelBase
         PortalUser = value;
         if (value != null)
         {
-            PortalUserThumbnail = ImageSource.FromStream((c) => value.GetThumbnailDataAsync());
+            if (value.ThumbnailUri == null)
+            {
+                PortalUserThumbnail = null;
+            }
+            else
+            {
+                PortalUserThumbnail = ImageSource.FromStream((c) => value.GetThumbnailDataAsync(c));
+            }
             _ = RefreshMaps(value.Portal);
         }
         else


### PR DESCRIPTION
This avoids GetThumbnailDataAsync throwing an InvalidOperationException.
Also forward the CancelationToken while we're at it.