### PR TITLE
MauiSignin: Make sure that StartupPage one-time setup only runs once

### DIFF
--- a/src/MauiSignin/AppSettings.cs
+++ b/src/MauiSignin/AppSettings.cs
@@ -82,6 +82,7 @@ internal class AppSettings : ModelBase
     {
         SetUser(null);
         OnPropertyChanged(nameof(Portal));
+        SecureStorage.Remove("License");
         await Esri.ArcGISRuntime.Security.AuthenticationManager.Current.RemoveAndRevokeAllCredentialsAsync();
     }
 }


### PR DESCRIPTION
The "loaded" event happens every time we return to the StartupPage (in the beginning, after OAuth authorization, and again after signing out), but some of the initialization only needs to happen once.