### PR TITLE
Add point editing styles to GeometryEditor demo

### DIFF
--- a/src/GeometryEditor/MyGeometryEditor.cs
+++ b/src/GeometryEditor/MyGeometryEditor.cs
@@ -140,14 +140,17 @@ namespace EditorDemo
                 if (geometry is Polygon)
                 {
                     _vertexTool.Style.FillSymbol = _rotateTool.Style.FillSymbol = _moveTool.Style.FillSymbol = _inactiveTool.Style.FillSymbol = symbol;
+                    _inactiveTool.Style.SelectedVertexSymbol = _inactiveTool.Style.VertexSymbol = _moveTool.Style.SelectedVertexSymbol = null;
                 }
                 else if (geometry is Polyline)
                 {
                     _vertexTool.Style.LineSymbol = _rotateTool.Style.LineSymbol = _moveTool.Style.LineSymbol = symbol;
                     _inactiveTool.Style.LineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Cyan, 2);
+                    _inactiveTool.Style.SelectedVertexSymbol = _inactiveTool.Style.VertexSymbol = _moveTool.Style.SelectedVertexSymbol = null;
                 }
                 else if (geometry is MapPoint || geometry is Multipoint)
                 {
+                    _inactiveTool.Style.VertexSymbol = _inactiveTool.Style.SelectedVertexSymbol = _moveTool.Style.SelectedVertexSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Square, System.Drawing.Color.Black, 9);
                 }
             }
             Start(geometry);


### PR DESCRIPTION
#### Description

Currently when selecting a point and activating the geometry editor the point vanishes and cannot be interacted with. This is because the styles that are set for polyline and polygon editing are null when editing a point. 

#### Background

There is an [esri community question](https://community.esri.com/t5/net-maps-sdk-questions/geometry-editor-move-or-rotate/m-p/1380622#M12522) which references the geometry editor demo. The user is having issues with the point selection symbol in the geometry editor and moving selected points.

#### Discussion

This may not be the perfect solution but I thought it would be a useful topic to raise for discussion. 