### PR TITLE
Upgrade to .NET 9 and update dependencies

### DIFF
--- a/src/ExternalNmeaGPS/ExternalNmeaGPS.Desktop/ExternalNmeaGPS.Desktop.csproj
+++ b/src/ExternalNmeaGPS/ExternalNmeaGPS.Desktop/ExternalNmeaGPS.Desktop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWPF>true</UseWPF>
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.5.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.6.0" />
     <PackageReference Include="Esri.Calcite.WPF" Version="0.1.0-preview1" />
   </ItemGroup>
 

--- a/src/GeocodeAndRoutingOnMouseMove/LocalNetworkSample.Desktop/LocalNetworkSample.Desktop.csproj
+++ b/src/GeocodeAndRoutingOnMouseMove/LocalNetworkSample.Desktop/LocalNetworkSample.Desktop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.3.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.6.0" />
   </ItemGroup>
 
 

--- a/src/GeocodeAndRoutingOnMouseMove/LocalNetworkSample.UWP/LocalNetworkSample.UWP.csproj
+++ b/src/GeocodeAndRoutingOnMouseMove/LocalNetworkSample.UWP/LocalNetworkSample.UWP.csproj
@@ -168,7 +168,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
-      <Version>200.3.0</Version>
+      <Version>200.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/src/GeometryEditor/EditorDemo.csproj
+++ b/src/GeometryEditor/EditorDemo.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.5.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.6.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="Esri.Calcite.WPF" Version="0.1.0-preview1" />

--- a/src/HydrographicsSample/HydrographicsSample.Desktop/HydrographicsSample.Desktop.csproj
+++ b/src/HydrographicsSample/HydrographicsSample.Desktop/HydrographicsSample.Desktop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.3.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.3.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.6.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="200.6.0" />
     <PackageReference Include="Esri.Calcite.Wpf" Version="0.1.0-preview1" />
   </ItemGroup>
   

--- a/src/KmlViewer/KmlViewer/KmlViewer.csproj
+++ b/src/KmlViewer/KmlViewer/KmlViewer.csproj
@@ -1,21 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>KmlViewer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
+    <Nullable>enable</Nullable>
     <EnableMsixTooling>true</EnableMsixTooling>
-    <WindowsSdkPackageVersion>10.0.19041.35-preview</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks> 
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="SampleData\RadarPreview.png" />
-  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -30,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240701003-experimental2" />
-    <PackageReference Include="Esri.ArcGISRuntime.WinUI" Version="200.5.0" />
+	 <PackageReference Include="Microsoft.UI.Xaml" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="WinUIEx" Version="2.3.4" />
     <ProjectReference Include="..\XInputHelper\XInputHelper.csproj" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/src/KmlViewer/KmlViewer/MainPage.xaml
+++ b/src/KmlViewer/KmlViewer/MainPage.xaml
@@ -42,15 +42,14 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <TitleBar Title="ArcGIS Maps SDK for .NET - KML Viewer" IsPaneToggleButtonVisible="True" PaneToggleRequested="BurgerButton_Toggled" x:Name="TitleBar">
-            <TitleBar.Footer>
+        <Grid x:Name="TitleBar" Background="LightGray" Height="50">
+            <TextBlock Text="ArcGIS Maps SDK for .NET - KML Viewer" VerticalAlignment="Center" Margin="10,0"/>
+            <Button Content="☰" HorizontalAlignment="Left" VerticalAlignment="Center" Click="BurgerButton_Toggled"/>
             <local:FindLocationControl LocationPicked="OnLocationPicked"
-                                       Width="200" HorizontalAlignment="Right"
-                                       VerticalAlignment="Center" BorderThickness="0" />
-            </TitleBar.Footer>
+                               Width="200" HorizontalAlignment="Right"
+                               VerticalAlignment="Center" BorderThickness="0" />
+        </Grid>
 
-        </TitleBar>
-        
         <SplitView x:Name="splitView" IsPaneOpen="True"  Grid.Row="1"
                    OpenPaneLength="350" CompactPaneLength="45" DisplayMode="Inline">
             <SplitView.Pane>

--- a/src/KmlViewer/KmlViewer/MainPage.xaml.cs
+++ b/src/KmlViewer/KmlViewer/MainPage.xaml.cs
@@ -462,9 +462,9 @@ namespace KmlViewer
 
         private bool isPanePinned = true;
 
-        private void BurgerButton_Toggled(TitleBar sender, object args)
+        private void BurgerButton_Toggled(object sender, RoutedEventArgs e)
         {
-            if(!isPanePinned)
+            if (!isPanePinned)
             {
                 splitView.DisplayMode = SplitViewDisplayMode.Inline;
                 splitView.IsPaneOpen = true;

--- a/src/KmlViewer/KmlViewer/MainWindow.xaml
+++ b/src/KmlViewer/KmlViewer/MainWindow.xaml
@@ -14,8 +14,5 @@
     xmlns:loc="using:Esri.ArcGISRuntime.Location"
     mc:Ignorable="d"
     >
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
     <local:MainPage />
 </Window>

--- a/src/KmlViewer/XInputHelper/XInputHelper.csproj
+++ b/src/KmlViewer/XInputHelper/XInputHelper.csproj
@@ -1,17 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <UseWinUI>true</UseWinUI>
   </PropertyGroup>
   <ItemGroup>
-   <PackageReference Include="Esri.ArcGISRuntime.WinUI">
-      <Version>200.5.0</Version>
+    <PackageReference Include="Esri.ArcGISRuntime.WinUI">
+      <Version>200.6.0</Version>
     </PackageReference>
     <PackageReference Include="SharpDX.XInput">
       <Version>4.2.0</Version>
     </PackageReference>
-	
   </ItemGroup>
 </Project>

--- a/src/MapViewer/ArcGISMapViewer/ArcGISMapViewer.csproj
+++ b/src/MapViewer/ArcGISMapViewer/ArcGISMapViewer.csproj
@@ -18,9 +18,6 @@
     <DefineConstants>DISABLE_XAML_GENERATED_MAIN;$(DefineConstants)</DefineConstants>
     <!--<PublishAot>True</PublishAot>-->
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Views\PortalItemDetailView.xaml" />
-  </ItemGroup>
 
     <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />

--- a/src/MauiSignin/MauiSignin.csproj
+++ b/src/MauiSignin/MauiSignin.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <RootNamespace>MauiSignin</RootNamespace>
         <UseMaui>true</UseMaui>
@@ -22,7 +22,7 @@
         <ApplicationVersion>1</ApplicationVersion>
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
@@ -33,7 +33,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-        <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.5.0" />
+        <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.6.0" />
         <PackageReference Include="WinUIEx" Version="2.3.4" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'" />
         <Using Include="Esri.ArcGISRuntime.Maui" />
         <Using Include="Esri.ArcGISRuntime.Mapping" />

--- a/src/OfflineWorkflowsSample/OfflineWorkflowsSample/OfflineWorkflowsSample.csproj
+++ b/src/OfflineWorkflowsSample/OfflineWorkflowsSample/OfflineWorkflowsSample.csproj
@@ -324,10 +324,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit.UWP">
-      <Version>200.5.0</Version>
+      <Version>200.6.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
-      <Version>200.5.0</Version>
+      <Version>200.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/src/SceneViewEdit/SceneEditingDemo/SceneEditingDemo.csproj
+++ b/src/SceneViewEdit/SceneEditingDemo/SceneEditingDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWPF>true</UseWPF>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.WPF">
-      <Version>200.3.0</Version>
+      <Version>200.6.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/SymbolEditor/SymbolEditorApp/SymbolEditorApp.csproj
+++ b/src/SymbolEditor/SymbolEditorApp/SymbolEditorApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <UseWPF>true</UseWPF>
     <AssemblyName>SymbolEditorApp</AssemblyName>
@@ -27,8 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="MahApps.Metro" Version="2.4.10" />
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="200.3.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.3.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WPF" Version="200.6.0" />
     <PackageReference Include="UniversalWPF" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/TurnByTurn/RoutingSample.Desktop/RoutingSample.Desktop.csproj
+++ b/src/TurnByTurn/RoutingSample.Desktop/RoutingSample.Desktop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWPF>true</UseWPF>
@@ -12,7 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.WPF">
-      <Version>200.3.0</Version>
+      <Version>200.6.0</Version>
     </PackageReference>
     <PackageReference Include="System.Speech">
       <Version>8.0.0</Version>

--- a/src/TurnByTurn/RoutingSample.MAUI/RoutingSample.MAUI.csproj
+++ b/src/TurnByTurn/RoutingSample.MAUI/RoutingSample.MAUI.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
@@ -24,7 +24,7 @@
     <ApplicationVersion>1</ApplicationVersion>
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
@@ -52,7 +52,7 @@
 
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.3.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Maui" Version="200.6.0" />
     <PackageReference Include="Esri.Calcite.Maui" Version="0.1.0-preview1" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>

--- a/src/TurnByTurn/RoutingSample.Universal/RoutingSample.Universal.csproj
+++ b/src/TurnByTurn/RoutingSample.Universal/RoutingSample.Universal.csproj
@@ -114,7 +114,7 @@
     <Content Include="Assets\SplashScreen.scale-200.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Properties\Default.rd.xml" />
-	<Content Include="..\RoutingSample.Shared\Assets\Maneuvers\**" Link="Assets\Maneuvers\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include="..\RoutingSample.Shared\Assets\Maneuvers\**" Link="Assets\Maneuvers\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -136,7 +136,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
-      <Version>200.3.0</Version>
+      <Version>200.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>


### PR DESCRIPTION
- Updated target framework from `net8.0` to `net9.0`.
- Updated `WindowsSdkPackageVersion` in `KmlViewer` from `10.0.19041.35-preview` to `10.0.19041.38`.
- Significant UI changes in `MainPage.xaml`, replacing `TitleBar` with a `Grid` containing a `TextBlock` and a `Button`.
- Updated `SupportedOSPlatformVersion` for `maccatalyst` in `MauiSignin` from `14.0` to `15.0`.
- Updated `Esri.ArcGISRuntime` dependencies from `200.5.0` to `200.6.0` across several projects.